### PR TITLE
Update odata-v4-parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/jaystack/odata-v4-sql#readme",
   "dependencies": {
     "odata-v4-literal": "^0.1.0",
-    "odata-v4-parser": "0.1.13"
+    "odata-v4-parser": "^0.1.19"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Current version of odata-v4-parser: 0.1.13 does not support Cyrillic characters.
As of now v0.1.29 does.

Please update odata-v4-parser version.